### PR TITLE
Fix to Ubuntu:xenical and install tesserocr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:xenial
 
 LABEL author="seo.cahill@parashift.io"
 
@@ -11,11 +11,13 @@ RUN \
     apt-get update -y \
     && apt-get install -y \
     build-essential \
+    git \
     ghostscript \
     imagemagick \
     libfile-mimeinfo-perl \
     libglib2.0.0 \
     mime-support \
+    openssh-client \
     poppler-utils \
     python3 \
     python3-dev \
@@ -30,7 +32,17 @@ RUN \
     libleptonica-dev \
     tesseract-ocr \
     tesseract-ocr-deu \
-    tesseract-ocr-eng 
+    tesseract-ocr-eng \
+    && pip3 install pip --upgrade \ 
+    && git clone https://github.com/sirfz/tesserocr.git \
+    && cd tesserocr \
+    && pip install . \
+    && cd .. \
+    && rm -rf tesserocr
+
+ADD https://github.com/tesseract-ocr/tessdata_best/raw/master/eng.traineddata /usr/share/tesseract-ocr/4.00/tessdata/eng.traineddata
+ADD https://github.com/tesseract-ocr/tessdata_best/raw/master/deu.traineddata /usr/share/tesseract-ocr/4.00/tessdata/deu.traineddata
+ADD https://github.com/tesseract-ocr/tessdata_best/raw/master/frk.traineddata /usr/share/tesseract-ocr/4.00/tessdata/frk.traineddata
 
 RUN \
   apt-get install -y curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ LABEL author="seo.cahill@parashift.io"
 ENV LANG C.UTF-8  
 ENV LC_ALL C.UTF-8 
 ENV PYTHONIOENCODING utf-8   
-
+ENV PYTHON_VERSION=3.5.2
+ENV PYTHON_MAJOR=3.5
 
 RUN \
     apt-get update -y \


### PR DESCRIPTION
Previously we used to build off `ubuntu:latest`.
- now changed to `ubuntu:xenical` (which was latest back when v0.0.8 was created)
- install `tesserocr` (python bindings for tesseract4)
- install latest training version of tesseract4
- upgrade python package installer (pip) to version 10.x

This should decrease build times of the other images that build off this. 

Fixes Issue #1 